### PR TITLE
Use an existing permission on settings page

### DIFF
--- a/vanilla-2.1.x/OneallSocialLogin/class.oneallsociallogin.plugin.php
+++ b/vanilla-2.1.x/OneallSocialLogin/class.oneallsociallogin.plugin.php
@@ -143,7 +143,7 @@ class OneallSocialLogin extends Gdn_Plugin
 	public function Controller_Index ($Sender) 
 	{
 		// Prevent non-admins from accessing this page
-		$Sender->Permission('Vanilla.Settings.Manage');
+		$Sender->Permission('Garden.Settings.Manage');
 
 		$oa_settings = array(
 				self::CONFIG_PREFIX . 'Enable' => C(self::CONFIG_PREFIX . 'Enable', 1),


### PR DESCRIPTION
This lets non-super admins use the page if they have the Garden.Settings.Manage permission.
